### PR TITLE
Add simple rail navigation website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Japan Rail Navigator</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Japan Rail Navigator</h1>
+    <p>Select a rail line to view its major stations.</p>
+  </header>
+  <main>
+    <label for="lineSelect">Rail Line:</label>
+    <select id="lineSelect">
+      <option value="">--Choose a line--</option>
+    </select>
+    <ul id="stationsList"></ul>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,39 @@
+const railLines = {
+  "Yamanote Line": [
+    "Tokyo", "Kanda", "Akihabara", "Ueno", "Ikebukuro",
+    "Shinjuku", "Shibuya", "Shinagawa", "Tamachi"
+  ],
+  "Chuo Line (Rapid)": [
+    "Tokyo", "Kanda", "Akihabara", "Ochanomizu", "Yotsuya",
+    "Shinjuku", "Nakano", "Mitaka"
+  ],
+  "Tokaido Shinkansen": [
+    "Tokyo", "Shinagawa", "Shin-Yokohama", "Nagoya",
+    "Kyoto", "Shin-Osaka"
+  ],
+  "Osaka Loop Line": [
+    "Osaka", "Kyobashi", "Osakajo-koen", "Tennoji",
+    "Nishikujo", "Fukushima", "Osaka"
+  ]
+};
+
+const selectEl = document.getElementById('lineSelect');
+const stationsList = document.getElementById('stationsList');
+
+// Populate dropdown
+for (const line of Object.keys(railLines)) {
+  const opt = document.createElement('option');
+  opt.value = line;
+  opt.textContent = line;
+  selectEl.appendChild(opt);
+}
+
+selectEl.addEventListener('change', () => {
+  stationsList.innerHTML = '';
+  const stations = railLines[selectEl.value] || [];
+  stations.forEach(station => {
+    const li = document.createElement('li');
+    li.textContent = station;
+    stationsList.appendChild(li);
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,36 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+  background-color: #f4f4f4;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+main {
+  max-width: 600px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+select {
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+#stationsList {
+  list-style: none;
+  padding-left: 0;
+}


### PR DESCRIPTION
## Summary
- build a minimal static web interface to display major Japanese rail lines
- include JavaScript to populate a dropdown and show stations
- add some basic styling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c857657f4832fbba6f0952feccdb3