### PR TITLE
Add Famichiki Finder site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Japanese Rail Lines Browser
+# Famichiki Finder
 
-This project provides a static web page for exploring the major rail lines across Japan. There is no build process or npm setup required; simply open `index.html` in your browser to view the site.
+This lighthearted page helps you locate the nearest Family Mart from a selected station. Choose a rail line, pick a station and enjoy the bouncing famichiki while reading the directions.
 
-For convenience, you can also serve the page locally with a simple HTTP server, such as:
+No build tools are required. Simply open `index.html` in your browser. To serve the page locally you can run:
 
 ```bash
 python3 -m http.server
 ```
 
-Then navigate to `http://localhost:8000` to browse the site.
+Then visit `http://localhost:8000`.

--- a/index.html
+++ b/index.html
@@ -3,21 +3,32 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Japan Rail Navigator</title>
+  <title>Famichiki Finder</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <header>
-    <h1>Japan Rail Navigator</h1>
-    <p>Select a rail line to view its major stations.</p>
+    <h1>Famichiki Finder</h1>
+    <p>Select your rail line and station to locate the nearest Family Mart.</p>
   </header>
   <main>
     <label for="lineSelect">Rail Line:</label>
     <select id="lineSelect">
       <option value="">--Choose a line--</option>
     </select>
-    <ul id="stationsList"></ul>
+    <label for="stationSelect">Station:</label>
+    <select id="stationSelect" disabled>
+      <option value="">--Choose a station--</option>
+    </select>
+    <div id="directions"></div>
   </main>
+  <div class="famichiki-container">
+    <span class="famichiki">🍗</span>
+    <span class="famichiki">🍗</span>
+    <span class="famichiki">🍗</span>
+    <span class="famichiki">🍗</span>
+    <span class="famichiki">🍗</span>
+  </div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -17,23 +17,81 @@ const railLines = {
   ]
 };
 
-const selectEl = document.getElementById('lineSelect');
-const stationsList = document.getElementById('stationsList');
+const stationDirections = {
+  "Tokyo": "Exit the central gate and you'll spot a Family Mart right beside the taxi stand.",
+  "Kanda": "Walk north toward the bus stop and cross the street for your famichiki fix.",
+  "Akihabara": "Take the Electric Town exit and follow the neon green sign.",
+  "Ueno": "Head to the park side exit, then turn left at the panda statue.",
+  "Ikebukuro": "Leave from the east exit and stroll two minutes toward Sunshine City.",
+  "Shinjuku": "Use the south exit and look for the store under the big video screen.",
+  "Shibuya": "Scramble across the crossing and you'll see Family Mart by the tall building.",
+  "Shinagawa": "Go out the konan exit and walk straight until the second traffic light.",
+  "Tamachi": "Take the west exit and turn right at the first corner.",
+  "Ochanomizu": "Exit toward the bridge and you'll find a store next to the bookstore.",
+  "Yotsuya": "Leave from the akasaka gate and walk downhill for one block.",
+  "Nakano": "Go out the north exit and it's beside the arcade entrance.",
+  "Mitaka": "Head to the south entrance and it's opposite the bus terminal.",
+  "Shin-Yokohama": "Exit the shinkansen gates and go down the escalator on your left.",
+  "Nagoya": "Take the sakura-dori exit and turn right at the big clock.",
+  "Kyoto": "Leave from the hachijo side and cross the street toward Kyoto Tower.",
+  "Shin-Osaka": "Exit the central gate, Family Mart is next to the souvenir shop.",
+  "Osaka": "Use the central exit and walk toward the ferris wheel.",
+  "Kyobashi": "Exit on the Keihan side and turn left at the first street.",
+  "Osakajo-koen": "Head toward the castle and it's by the bicycle parking.",
+  "Tennoji": "Leave from the north exit and walk past the zoo entrance.",
+  "Nishikujo": "Take the east exit and cross the small bridge.",
+  "Fukushima": "Exit the platform stairs and turn right at the main road."
+};
 
-// Populate dropdown
+const lineSelect = document.getElementById('lineSelect');
+const stationSelect = document.getElementById('stationSelect');
+const directionsDiv = document.getElementById('directions');
+
 for (const line of Object.keys(railLines)) {
   const opt = document.createElement('option');
   opt.value = line;
   opt.textContent = line;
-  selectEl.appendChild(opt);
+  lineSelect.appendChild(opt);
 }
 
-selectEl.addEventListener('change', () => {
-  stationsList.innerHTML = '';
-  const stations = railLines[selectEl.value] || [];
+lineSelect.addEventListener('change', () => {
+  const stations = railLines[lineSelect.value] || [];
+  stationSelect.innerHTML = '<option value="">--Choose a station--</option>';
+  stationSelect.disabled = stations.length === 0;
   stations.forEach(station => {
-    const li = document.createElement('li');
-    li.textContent = station;
-    stationsList.appendChild(li);
+    const opt = document.createElement('option');
+    opt.value = station;
+    opt.textContent = station;
+    stationSelect.appendChild(opt);
   });
+  directionsDiv.textContent = '';
+});
+
+stationSelect.addEventListener('change', () => {
+  const station = stationSelect.value;
+  directionsDiv.textContent = stationDirections[station] || '';
+  if (stationDirections[station]) {
+    playSound();
+  }
+});
+
+function playSound() {
+  try {
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const oscillator = ctx.createOscillator();
+    oscillator.type = 'triangle';
+    oscillator.frequency.setValueAtTime(660, ctx.currentTime);
+    oscillator.connect(ctx.destination);
+    oscillator.start();
+    oscillator.stop(ctx.currentTime + 0.15);
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+// Randomize famichiki positions
+const famichikis = document.querySelectorAll('.famichiki');
+famichikis.forEach(f => {
+  f.style.left = Math.random() * 100 + 'vw';
+  f.style.top = Math.random() * 100 + 'vh';
 });

--- a/styles.css
+++ b/styles.css
@@ -2,21 +2,26 @@ body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 1rem;
-  background-color: #f4f4f4;
+  background-color: #ffffff;
+  color: #333;
 }
 
 header {
   text-align: center;
   margin-bottom: 1rem;
+  background: linear-gradient(to bottom, #00a0e9, #00b041);
+  color: #fff;
+  padding: 1rem 0;
 }
 
 main {
   max-width: 600px;
-  margin: 0 auto;
+  margin: 1rem auto;
   background: #fff;
   padding: 1rem;
-  border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  border-radius: 8px;
+  border: 4px solid #00a0e9;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 
 label {
@@ -28,9 +33,40 @@ select {
   width: 100%;
   padding: 0.5rem;
   margin-bottom: 1rem;
+  border: 2px solid #00b041;
+  border-radius: 4px;
 }
 
-#stationsList {
-  list-style: none;
-  padding-left: 0;
+#directions {
+  margin-top: 1rem;
+  font-size: 1.2rem;
+  font-weight: bold;
+  color: #00b041;
+}
+
+.famichiki-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: -1;
+}
+
+.famichiki {
+  position: absolute;
+  font-size: 2rem;
+  animation: bounce 2s infinite ease-in-out, drift 10s infinite linear;
+}
+
+@keyframes bounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-30px); }
+}
+
+@keyframes drift {
+  from { transform: translateX(-10vw); }
+  to { transform: translateX(110vw); }
 }


### PR DESCRIPTION
## Summary
- rework the page into a quirky "Famichiki Finder"
- allow choosing line and station to display directions
- add bouncing famichiki animations and sound effect
- update styling to match Family Mart colors
- update README to describe the new purpose

## Testing
- `python3 -m http.server`

------
https://chatgpt.com/codex/tasks/task_e_6851f3fe45b8832f8d866a0c944bdeba